### PR TITLE
Test api/restaurant/menu endpoint

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,62 +1,82 @@
 from django.urls import reverse
-from django.test import TestCase
 from django.contrib.auth.models import User
-from rest_framework.test import force_authenticate, APIRequestFactory
-from rest_framework import status
+from rest_framework.test import force_authenticate, APIRequestFactory, APITestCase
 from decimal import Decimal
-import ast
-from RMS.models.DishRestaurantMenuEntry import DishRestaurantMenuEntry
+from RMS.models.DishRestaurantMenuEntry import *
+from RMS.models.DrinkRestaurantMenuEntry import *
+from RMS.models.RestaurantMenuEntry import *
 from api.views import RestaurantMenuEntryListView, RestaurantMenuEntryDetailView
 
 
-class RestaurantMenuEntryListViewTests(TestCase):
+class RestaurantMenuEntryListViewTests(APITestCase):
     def setUp(self) -> None:
-        DishRestaurantMenuEntry.objects.all().delete()
+        RestaurantMenuEntry.objects.all().delete()
         self.assertEqual(DishRestaurantMenuEntry.objects.all().exists(), False)
-        self.test_DishMenuEntry1 = DishRestaurantMenuEntry.objects.create(name='Eggs Benedict',
-                                                                          price=Decimal('29.99'),
-                                                                          stage=DishRestaurantMenuEntry.DishStage.MAIN_COURSE,
-                                                                          weight=Decimal('0.3'))
-        self.test_DishMenuEntry2 = DishRestaurantMenuEntry.objects.create(name='Toast with ham',
-                                                                          price=Decimal('9.99'),
-                                                                          stage=DishRestaurantMenuEntry.DishStage.STARTER,
-                                                                          weight=Decimal('0.1'))
+        self.eggs = DishRestaurantMenuEntry.objects.create(name='Eggs Benedict',
+                                                           price=Decimal('29.99'),
+                                                           stage=DishRestaurantMenuEntry.DishStage.MAIN_COURSE,
+                                                           weight=Decimal('0.3'))
+        self.toast = DishRestaurantMenuEntry.objects.create(name='Toast with ham',
+                                                            price=Decimal('9.99'),
+                                                            stage=DishRestaurantMenuEntry.DishStage.STARTER,
+                                                            weight=Decimal('0.1'))
+        self.coke = DrinkRestaurantMenuEntry.objects.create(name='Coca Cola',
+                                                            price=Decimal('2.99'),
+                                                            volume=Decimal('0.33'))
+        self.booze = DrinkRestaurantMenuEntry.objects.create(name='Heineken',
+                                                             price=Decimal('5.40'),
+                                                             contains_alcohol=True,
+                                                             volume=Decimal('0.5'))
 
         self.test_user1 = User.objects.create(username='test_user1')
         self.test_user1.set_password('123')
         self.test_user1.save()
         self.assertEqual(len(User.objects.all()), 1)
-        self.factory = APIRequestFactory()
-        self.list_view = RestaurantMenuEntryListView.as_view()
-        self.detail_view = RestaurantMenuEntryDetailView.as_view()
 
-    def test_get_DishRestaurantMenuEntry_list(self):
+    def test_get_RestaurantMenuEntry_list(self):
+        """
+        Ensure unauthenticated GET method on /api/restaurant/menu endpoint is working.
+        """
         url = reverse('api:menu_entry_list')
-        request = self.factory.get(url)
-        force_authenticate(request, user=self.test_user1)
-        response = self.list_view(request)
+        response = self.client.get(url, format='json')
+        self.assertEqual(len(response.data), 4)
+        self.assertContains(response=response,
+                            text='Eggs Benedict',
+                            count=1,
+                            status_code=200)
+        self.assertContains(response=response,
+                            text='Toast with ham',
+                            count=1,
+                            status_code=200)
+        self.assertContains(response=response,
+                            text='Coca Cola',
+                            count=1,
+                            status_code=200)
+        self.assertContains(response=response,
+                            text='Heineken',
+                            count=1,
+                            status_code=200)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(ast.literal_eval(response.rendered_content.decode('utf-8'))), 2)
-        self.assertContains(response, text='Eggs Benedict', count=1)
-        self.assertContains(response, text='Toast with ham', count=1)
-
-    def test_post_DishRestaurantMenuEntry_list(self):
+    def test_post_Dish_to_RestaurantMenuEntry_list(self):
+        """
+        Ensure unauthenticated POST method on /api/restaurant/menu endpoint is working.
+        """
         url = reverse('api:menu_entry_list')
-        body = \
+        data = \
             {
                 'name': 'Scrambled eggs',
                 'price': '20.54',
                 'stage': '2',
-                'weight': '0.250'
+                'weight': '0.250',
+                'resourcetype': 'DishRestaurantMenuEntry'
             }
 
-        request = self.factory.post(url, body, format='json')
-        force_authenticate(request, user=self.test_user1)
-        response = self.list_view(request)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        request = self.factory.get(url)
-        force_authenticate(request, user=self.test_user1)
-        response = self.list_view(request)
-        self.assertContains(response, text='Scrambled eggs', count=1)
+        previous_count = DishRestaurantMenuEntry.objects.count()
+        response = self.client.post(url, data, format='json')
+        # force_authenticate(request, user=self.test_user1)
+        self.assertContains(response=response,
+                            text='Scrambled eggs',
+                            count=1,
+                            status_code=201)
+        self.assertEqual(DishRestaurantMenuEntry.objects.count(), previous_count + 1)
+        self.assertTrue(DishRestaurantMenuEntry.objects.filter(name='Scrambled eggs').exists())

--- a/api/tests.py
+++ b/api/tests.py
@@ -59,7 +59,7 @@ class RestaurantMenuEntryListViewTests(APITestCase):
 
     def test_post_Dish_to_RestaurantMenuEntry_list(self):
         """
-        Ensure unauthenticated POST method on /api/restaurant/menu endpoint is working.
+        Ensure unauthenticated POST method with DishRestaurantMenuEntry on /api/restaurant/menu endpoint is working.
         """
         url = reverse('api:menu_entry_list')
         data = \
@@ -80,3 +80,27 @@ class RestaurantMenuEntryListViewTests(APITestCase):
                             status_code=201)
         self.assertEqual(DishRestaurantMenuEntry.objects.count(), previous_count + 1)
         self.assertTrue(DishRestaurantMenuEntry.objects.filter(name='Scrambled eggs').exists())
+
+    def test_post_Drink_to_RestaurantMenuEntry_list(self):
+        """
+        Ensure unauthenticated POST method with DrinkRestaurantMenuEntry on /api/restaurant/menu endpoint is working.
+        """
+        url = reverse('api:menu_entry_list')
+        data = \
+            {
+                'name': 'Fanta',
+                'price': '1.39',
+                'contains_alcohol': False,
+                'volume': '0.33',
+                'resourcetype': 'DrinkRestaurantMenuEntry'
+            }
+
+        previous_count = DrinkRestaurantMenuEntry.objects.count()
+        response = self.client.post(url, data, format='json')
+        # force_authenticate(request, user=self.test_user1)
+        self.assertContains(response=response,
+                            text='Fanta',
+                            count=1,
+                            status_code=201)
+        self.assertEqual(DrinkRestaurantMenuEntry.objects.count(), previous_count + 1)
+        self.assertTrue(DrinkRestaurantMenuEntry.objects.filter(name='Fanta').exists())


### PR DESCRIPTION
Refreshed the tests for the api/restaurant/menu API endpoint which now work with new inheritance structure of RestaurantMenuEntry tree (now the enpoint shows both Dishes and Drinks). All the requests are still **unauthorized**.